### PR TITLE
Fixes #6 again. Sets packages to empty array instead of a hash table if 0 packages installed

### DIFF
--- a/src/ConDep.Dsl/Harvesters/OperatingSystemHarvester.cs
+++ b/src/ConDep.Dsl/Harvesters/OperatingSystemHarvester.cs
@@ -63,7 +63,7 @@ namespace ConDep.Dsl.Harvesters
     
     [array] $packages = Get-ChildItem -Path $regKeys | Get-ItemProperty | where-object { $_.DisplayName -ne $null } | select-object -Property DisplayName,DisplayVersion | foreach{$_.DisplayName + "";"" + $_.DisplayVersion}
     if($packages -eq $null) {
-        $packages = @{}
+        $packages = @()
     } 
     $osInfo.InstalledSoftwarePackages = $packages
 


### PR DESCRIPTION
Fixed in v4.0.2 branch as well: https://github.com/condep/condep-dsl/commit/46461b5d4cad805900b0d138a54ff012b1194620