### PR TITLE
Add offline priority loadbalancer mode

### DIFF
--- a/src/ConDep.Dsl.Tests/MockLoadBalancer.cs
+++ b/src/ConDep.Dsl.Tests/MockLoadBalancer.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using ConDep.Dsl.Config;
+using ConDep.Dsl.LoadBalancer;
 
 namespace ConDep.Dsl.Tests
 {
@@ -21,6 +23,22 @@ namespace ConDep.Dsl.Tests
         }
 
         public LoadBalancerMode Mode { get; set; }
+
+        public LoadBalanceState GetServerState(string serverName, string farm)
+        {
+            var serverState = _onlineOfflineSequence.FindLast(p => p.Item1 == serverName);
+            if (serverState == null)
+                return LoadBalanceState.Online;
+            var state = serverState.Item2;
+            switch (state)
+            {
+                case "online":
+                    return LoadBalanceState.Online;
+                case "offline":
+                    return LoadBalanceState.Offline;
+            }
+            throw new Exception("Last onlineOfflineSequence state of server was neither online or offline.");
+        }
 
         public IList<Tuple<string, string>> OnlineOfflineSequence { get { return _onlineOfflineSequence; } }
     }

--- a/src/ConDep.Dsl/ConDep.Dsl.csproj
+++ b/src/ConDep.Dsl/ConDep.Dsl.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Config\ConDepMissingOptionsException.cs" />
     <Compile Include="IOfferOperations.cs" />
     <Compile Include="IOfferResult.cs" />
+    <Compile Include="LoadBalancer\OfflinePriorityLoadBalancerExecutor.cs" />
     <Compile Include="LocalOperation.cs" />
     <Compile Include="OperationExecutor.cs" />
     <Compile Include="OperationsBuilder.cs" />

--- a/src/ConDep.Dsl/Config/LoadBalancerMode.cs
+++ b/src/ConDep.Dsl/Config/LoadBalancerMode.cs
@@ -18,9 +18,14 @@ namespace ConDep.Dsl.Config
 
         /// <summary>
         /// Each server will be taken offline, operations executed and then taken online
-        /// again immidiately. This is the recommended approuch since it causes the least
+        /// again immidiately. This is the recommended approach since it causes the least
         /// downtime, but will require your load balancer to handle Sticky Sessions.
         /// </summary>
-        Sticky
+        Sticky,
+
+        /// <summary>
+        /// Like Sticky, but prioritises the already offline load balancers.
+        /// </summary>
+        OfflinePriority
     }
 }

--- a/src/ConDep.Dsl/ILoadBalance.cs
+++ b/src/ConDep.Dsl/ILoadBalance.cs
@@ -1,4 +1,5 @@
 ﻿using ConDep.Dsl.Config;
+using ConDep.Dsl.LoadBalancer;
 
 namespace ConDep.Dsl
 {
@@ -10,5 +11,6 @@ namespace ConDep.Dsl
         Result BringOffline(string serverName, string farm, LoadBalancerSuspendMethod suspendMethod);
         Result BringOnline(string serverName, string farm);
         LoadBalancerMode Mode { get; set; }
+        LoadBalanceState GetServerState(string serverName, string farm);
     }
 }

--- a/src/ConDep.Dsl/IOfferOperations.cs
+++ b/src/ConDep.Dsl/IOfferOperations.cs
@@ -12,7 +12,7 @@ namespace ConDep.Dsl
         /// </summary>
         /// <param name="mode">Which load balancer mode to use during execution</param>
         /// <param name="farm"></param>
-        /// <param name="dsl"></param>
+        /// <param name="remote"></param>
         /// <returns></returns>
         IOfferOperations LoadBalance(LoadBalancerMode mode, string farm, Action<IOfferRemoteOperations> remote);
 

--- a/src/ConDep.Dsl/LoadBalancer/LoadBalancerExecutorBase.cs
+++ b/src/ConDep.Dsl/LoadBalancer/LoadBalancerExecutorBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -11,11 +12,12 @@ namespace ConDep.Dsl.LoadBalancer
         public abstract void BringOffline(ServerConfig server, ConDepSettings settings, CancellationToken token);
         public abstract void BringOnline(ServerConfig server, ConDepSettings settings, CancellationToken token);
 
-        public virtual IEnumerable<ServerConfig> GetServerExecutionOrder(List<ServerConfig> servers, ConDepSettings settings, CancellationToken token)
+        public virtual IEnumerable<ServerConfig> GetServerExecutionOrder(List<ServerConfig> servers,
+            ConDepSettings settings, CancellationToken token)
         {
             if (settings.Options.StopAfterMarkedServer)
             {
-                return new[] { servers.SingleOrDefault(x => x.StopServer) ?? servers.First() };
+                return new[] {servers.SingleOrDefault(x => x.StopServer) ?? servers.First()};
             }
 
             if (settings.Options.ContinueAfterMarkedServer)
@@ -23,13 +25,14 @@ namespace ConDep.Dsl.LoadBalancer
                 var markedServer = servers.SingleOrDefault(x => x.StopServer) ?? servers.First();
                 BringOnline(markedServer, settings, token);
 
-                return servers.Count == 1 ? new List<ServerConfig>() : servers.Except(new[] { markedServer });
+                return servers.Count == 1 ? new List<ServerConfig>() : servers.Except(new[] {markedServer});
             }
 
             return servers;
         }
 
-        protected void BringOffline(ServerConfig server, ConDepSettings settings, ILoadBalance loadBalancer, CancellationToken token)
+        protected void BringOffline(ServerConfig server, ConDepSettings settings, ILoadBalance loadBalancer,
+            CancellationToken token)
         {
             if (settings.Config.LoadBalancer == null) return;
             if (server.LoadBalancerState.CurrentState == LoadBalanceState.Offline) return;
@@ -41,7 +44,9 @@ namespace ConDep.Dsl.LoadBalancer
             });
 
         }
-        protected void BringOnline(ServerConfig server, ConDepSettings settings, ILoadBalance loadBalancer, CancellationToken token)
+
+        protected void BringOnline(ServerConfig server, ConDepSettings settings, ILoadBalance loadBalancer,
+            CancellationToken token)
         {
             if (settings.Config.LoadBalancer == null) return;
             if (server.LoadBalancerState.CurrentState == LoadBalanceState.Online) return;
@@ -52,6 +57,12 @@ namespace ConDep.Dsl.LoadBalancer
                 server.LoadBalancerState.CurrentState = LoadBalanceState.Online;
             });
 
+        }
+
+        protected LoadBalanceState GetServerState(ServerConfig server, ILoadBalance loadBalancer)
+        {
+            if (loadBalancer == null) throw new ArgumentException("Missing loadbalancer");
+            return loadBalancer.GetServerState(server.Name, server.LoadBalancerFarm);
         }
     }
 }

--- a/src/ConDep.Dsl/LoadBalancer/OfflinePriorityLoadBalancerExecutor.cs
+++ b/src/ConDep.Dsl/LoadBalancer/OfflinePriorityLoadBalancerExecutor.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using ConDep.Dsl.Config;
+
+namespace ConDep.Dsl.LoadBalancer
+{
+    public class OfflinePriorityLoadBalancerExecutor : StickyLoadBalancerExecutor
+    {
+
+        private readonly ILoadBalance _loadBalancer;
+        public OfflinePriorityLoadBalancerExecutor(ILoadBalance loadBalancer) : base(loadBalancer)
+        {
+            _loadBalancer = loadBalancer;
+        }
+
+        public override IEnumerable<ServerConfig> GetServerExecutionOrder(List<ServerConfig> servers, ConDepSettings settings, CancellationToken token)
+        {
+            return base.GetServerExecutionOrder(servers, settings, token).OrderBy(server =>
+                GetServerState(server,_loadBalancer) == LoadBalanceState.Online );
+        }
+    }
+}

--- a/src/ConDep.Dsl/OperationsBuilder.cs
+++ b/src/ConDep.Dsl/OperationsBuilder.cs
@@ -282,6 +282,9 @@ namespace ConDep.Dsl
                 case LoadBalancerMode.Sticky:
                     lbExecutor = new StickyLoadBalancerExecutor(loadBalancer);
                     break;
+                case LoadBalancerMode.OfflinePriority:
+                    lbExecutor = new OfflinePriorityLoadBalancerExecutor(loadBalancer);
+                    break;
                 default:
                     throw new ConDepLoadBalancerException("Load balancer mode not supported");
             }


### PR DESCRIPTION
Added an offline priority load balancer mode.
This changes the interface of the load balancer providers, so they need to implement one more function.
Some changes to the aloha-haproxy and condep-execution repos will follow.